### PR TITLE
Remove target branch from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
       day: "saturday"
       time: "09:00"
       timezone: "America/New_York"
-    target-branch: "feature/dependency-updates"
     commit-message:
       prefix: "deps"
       include: "scope"


### PR DESCRIPTION
Change target branch for dependency updates.